### PR TITLE
bug fix: obsID and qID names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: conjointTools
 Title: Tools For Designing Conjoint Survey Experiments
-Version: 0.0.8.9000
+Version: 0.0.8.9001
 Maintainer: John Helveston <john.helveston@gmail.com>
 Authors@R: c(
     person(given   = "John",

--- a/R/estimateModels.R
+++ b/R/estimateModels.R
@@ -7,6 +7,8 @@
 #' @keywords logitr, mnl, mxl, logit, sample size, power
 #'
 #' @param nbreaks The number of different sample size groups.
+#' @param nQPerResp Number of questions per respondent. Defaults to `1` if not
+#' specified.
 #' @param data The data, formatted as a `data.frame` object.
 #' @param outcome The name of the column that identifies the outcome variable,
 #' which should be coded with a `1` for `TRUE` and `0` for `FALSE`.
@@ -108,6 +110,7 @@
 #' )
 estimateModels <- function(
   nbreaks = 10,
+  nQPerResp = 1,
   data,
   outcome,
   obsID,
@@ -139,7 +142,7 @@ estimateModels <- function(
     algorithm   = "NLOPT_LD_LBFGS"
   )
 ) {
-    dataList <- makeDataList(data, obsID, nbreaks)
+    dataList <- makeDataList(data, obsID, nbreaks, nQPerResp)
     suppressMessages(
       result <- structure(lapply(
           dataList,
@@ -171,13 +174,13 @@ estimateModels <- function(
     return(result)
 }
 
-makeDataList <- function(data, obsID, nbreaks) {
+makeDataList <- function(data, obsID, nbreaks, nQPerResp) {
     maxObs <- max(data[obsID])
     nObs <- ceiling(seq(ceiling(maxObs/nbreaks), maxObs, length.out = nbreaks))
     dataList <- list()
     for (i in 1:nbreaks) {
-      temp <- data[which(data$obsID %in% seq(nObs[i])),]
-      temp$sampleSize <- round(nObs[i] / max(temp$qID))
+      temp <- data[which(data[,obsID] %in% seq(nObs[i])),]
+      temp$sampleSize <- round(nObs[i] / nQPerResp)
       dataList[[i]] <- temp
     }
     sampleSizes <- unlist(lapply(dataList, function(x) unique(x$sampleSize)))

--- a/man/estimateModels.Rd
+++ b/man/estimateModels.Rd
@@ -6,6 +6,7 @@
 \usage{
 estimateModels(
   nbreaks = 10,
+  nQPerResp = 1,
   data,
   outcome,
   obsID,
@@ -33,6 +34,9 @@ estimateModels(
 }
 \arguments{
 \item{nbreaks}{The number of different sample size groups.}
+
+\item{nQPerResp}{Number of questions per respondent. Defaults to \code{1} if not
+specified.}
 
 \item{data}{The data, formatted as a \code{data.frame} object.}
 


### PR DESCRIPTION
- obsID was being called using data$obsID, switched to data[,obsID] so that the obsID argument would be used.
- added a nQPerResp argument to determine sample size based on how many questions are asked of each respondent